### PR TITLE
Alert Storm processing changes

### DIFF
--- a/AlertManagement.PS/escalate.alert.config
+++ b/AlertManagement.PS/escalate.alert.config
@@ -5,20 +5,13 @@
         <outputpath name="D:\Admin\Scripts\EscalateScomAlerts\Logs" />
     </settings>
 	<alertStormRules>
-        <!--<stormRule name="Health Service Heartbeat Failure" enabled="false">
-            <Sequence>1</Sequence>
-            <Criteria><![CDATA["Name='Health Service Heartbeat Failure' AND (ResolutionState=0 OR ResolutionState=5) AND TimeRaised > '__TimeRaised__'"]]></Criteria>
-            <count>10</count>
-            <window>5</window>
-            <NewResolutionState>18</NewResolutionState>
-            <Comment><![CDATA["Alert updated by the alert automation: Alert Storm"]]></Comment>
-            <SendNotification>Y</SendNotification>
-            <NotificationRecipients></NotificationRecipients>
-        </stormRule>-->
-        <stormRule name="Alert Count by Name" enabled="true">
+	<alertStormRules>
+		<stormRule name="Alert Count by Name" enabled="true">
             <Sequence>100</Sequence>
 			<Property>Name</Property>
-            <count>10</count>
+			<Criteria><![CDATA[ResolutionState<>255]]></Criteria>
+            <Count>10</Count>
+			<Window>5</Window>
             <NewResolutionState>18</NewResolutionState>
             <Comment><![CDATA[Alert updated by the alert automation: Alert Storm]]></Comment>
             <SendNotification>N</SendNotification>
@@ -27,7 +20,9 @@
 		<stormRule name="Alert count by MonitoringObjectId" enabled="true">
             <Sequence>101</Sequence>
 			<Property>MonitoringObjectId</Property>
-            <count>10</count>
+            <Criteria><![CDATA[ResolutionState<>255]]></Criteria>
+            <Count>10</Count>
+			<Window>5</Window>
             <NewResolutionState>18</NewResolutionState>
             <Comment><![CDATA[Alert updated by the alert automation: Alert Storm]]></Comment>
             <SendNotification>N</SendNotification>


### PR DESCRIPTION
- Determine if an alert's object is deployed before creating a storm for it
- Add alerts to an existing storm
- Use a sliding window to detect the beginning and end of a storm