### PR TITLE
Fix build triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,15 +2,9 @@ name: Build Management Pack
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request
   push:
     branches:
-      - '*'         # matches every branch that doesn't contain a '/'
-      - '*/*'       # matches every branch containing a single '/'
       - '**'        # matches every branch
-      - '!dev'      # excludes dev
-      - '!main'     # excludes main
-  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/AlertManagement/AlertManagement.mpproj
+++ b/AlertManagement/AlertManagement.mpproj
@@ -5,7 +5,7 @@
     <RootNamespace>SCOM.Alert.Management</RootNamespace>
     <Name>SCOM.Alert.Management</Name>
     <ManagementPackName>SCOM.Alert.Management</ManagementPackName>
-    <Version>1.2.35.113</Version>
+    <Version>1.2.36.114</Version>
     <MpFrameworkVersion>v7.0.2</MpFrameworkVersion>
     <MpFrameworkProfile>OM</MpFrameworkProfile>
     <ProductVersion>1.1.0.0</ProductVersion>

--- a/AlertManagement/AlertManagement.mpproj
+++ b/AlertManagement/AlertManagement.mpproj
@@ -5,7 +5,7 @@
     <RootNamespace>SCOM.Alert.Management</RootNamespace>
     <Name>SCOM.Alert.Management</Name>
     <ManagementPackName>SCOM.Alert.Management</ManagementPackName>
-    <Version>1.2.34.112</Version>
+    <Version>1.2.35.113</Version>
     <MpFrameworkVersion>v7.0.2</MpFrameworkVersion>
     <MpFrameworkProfile>OM</MpFrameworkProfile>
     <ProductVersion>1.1.0.0</ProductVersion>

--- a/AlertManagement/AlertManagement.mpproj.user
+++ b/AlertManagement/AlertManagement.mpproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <DeploymentNextVersion>1.2.35.114</DeploymentNextVersion>
+    <DeploymentNextVersion>1.2.36.115</DeploymentNextVersion>
     <DeploymentAutoIncrementVersion>True</DeploymentAutoIncrementVersion>
     <DeploymentStartAction>None</DeploymentStartAction>
     <DeploymentWebConsoleUrl />

--- a/AlertManagement/AlertManagement.mpproj.user
+++ b/AlertManagement/AlertManagement.mpproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <DeploymentNextVersion>1.2.34.113</DeploymentNextVersion>
+    <DeploymentNextVersion>1.2.35.114</DeploymentNextVersion>
     <DeploymentAutoIncrementVersion>True</DeploymentAutoIncrementVersion>
     <DeploymentStartAction>None</DeploymentStartAction>
     <DeploymentWebConsoleUrl />


### PR DESCRIPTION
Prevent build to run on pull requests, but runs on pushes. This should still trigger at the completion of a PR to dev or main.